### PR TITLE
Control font choices via command line option

### DIFF
--- a/resources/fonts.json
+++ b/resources/fonts.json
@@ -1,0 +1,44 @@
+{
+  "allGentium": {
+    "body": "\"Gentium Book Plus\", serif",
+    "heading": "\"Gentium Book Plus\", serif",
+    "footnotes": "\"Gentium Book Plus\", serif",
+    "greek": "\"Gentium Book Plus\", serif",
+    "hebrew": "\"Ezra SIL\", serif"
+  },
+  "allCharis": {
+    "body": "\"Charis SIL\", serif",
+    "heading": "\"Charis SIL\", serif",
+    "footnotes": "\"Charis SIL\", serif",
+    "greek": "\"Gentium Book Plus\", serif",
+    "hebrew": "\"Ezra SIL\", serif"
+  },
+  "allCardo": {
+    "body": "Cardo, serif",
+    "heading": "Cardo, serif",
+    "footnotes": "Cardo, serif",
+    "greek": "Cardo, serif",
+    "hebrew": "\"Ezra SIL\", serif"
+  },
+  "allRoboto": {
+    "body": "Roboto, sans-serif",
+    "heading": "Roboto, sans-serif",
+    "footnotes": "Roboto, sans-serif",
+    "greek": "\"Gentium Book Plus\", serif",
+    "hebrew": "\"Ezra SIL\", serif"
+  },
+  "allAndika": {
+    "body": "Andika, serif",
+    "heading": "Andika, serif",
+    "footnotes": "Andika, serif",
+    "greek": "Andika, serif",
+    "hebrew": "\"Ezra SIL\", serif"
+  },
+  "charisOpen": {
+    "body": "\"Charis SIL\", serif",
+    "heading": "\"Open Sans\", serif",
+    "footnotes": "\"Charis SIL\", serif",
+    "greek": "\"Gentium Book Plus\", serif",
+    "hebrew": "\"Ezra SIL\", serif"
+  }
+}

--- a/resources/fonts.json
+++ b/resources/fonts.json
@@ -2,35 +2,35 @@
   "allGentium": {
     "body": "\"Gentium Book Plus\", serif",
     "heading": "\"Gentium Book Plus\", serif",
-    "footnotes": "\"Gentium Book Plus\", serif",
+    "footnote": "\"Gentium Book Plus\", serif",
     "greek": "\"Gentium Book Plus\", serif",
     "hebrew": "\"Ezra SIL\", serif"
   },
   "allCharis": {
     "body": "\"Charis SIL\", serif",
     "heading": "\"Charis SIL\", serif",
-    "footnotes": "\"Charis SIL\", serif",
+    "footnote": "\"Charis SIL\", serif",
     "greek": "\"Gentium Book Plus\", serif",
     "hebrew": "\"Ezra SIL\", serif"
   },
   "allCardo": {
     "body": "Cardo, serif",
     "heading": "Cardo, serif",
-    "footnotes": "Cardo, serif",
+    "footnote": "Cardo, serif",
     "greek": "Cardo, serif",
     "hebrew": "\"Ezra SIL\", serif"
   },
   "allRoboto": {
     "body": "Roboto, sans-serif",
     "heading": "Roboto, sans-serif",
-    "footnotes": "Roboto, sans-serif",
+    "footnote": "Roboto, sans-serif",
     "greek": "\"Gentium Book Plus\", serif",
     "hebrew": "\"Ezra SIL\", serif"
   },
   "allAndika": {
     "body": "Andika, serif",
     "heading": "Andika, serif",
-    "footnotes": "Andika, serif",
+    "footnote": "Andika, serif",
     "greek": "Andika, serif",
     "hebrew": "\"Ezra SIL\", serif"
   },

--- a/resources/fonts.json
+++ b/resources/fonts.json
@@ -1,6 +1,15 @@
 {
+  "test": {
+    "body": "ani",
+    "body2": "purisa",
+    "heading": "kalimati",
+    "footnote": "karumbi",
+    "greek": "\"Gentium Book Plus\", serif",
+    "hebrew": "\"Ezra SIL\", serif"
+  },
   "allGentium": {
     "body": "\"Gentium Book Plus\", serif",
+    "body2": "\"Open Sans Condensed Light\", sans-serif",
     "heading": "\"Gentium Book Plus\", serif",
     "footnote": "\"Gentium Book Plus\", serif",
     "greek": "\"Gentium Book Plus\", serif",
@@ -8,6 +17,7 @@
   },
   "allCharis": {
     "body": "\"Charis SIL\", serif",
+    "body2": "\"Open Sans Condensed Light\", sans-serif",
     "heading": "\"Charis SIL\", serif",
     "footnote": "\"Charis SIL\", serif",
     "greek": "\"Gentium Book Plus\", serif",
@@ -15,6 +25,7 @@
   },
   "allCardo": {
     "body": "Cardo, serif",
+    "body2": "\"Open Sans Condensed Light\", sans-serif",
     "heading": "Cardo, serif",
     "footnote": "Cardo, serif",
     "greek": "Cardo, serif",
@@ -22,6 +33,7 @@
   },
   "allRoboto": {
     "body": "Roboto, sans-serif",
+    "body2": "\"Open Sans Condensed Light\", sans-serif",
     "heading": "Roboto, sans-serif",
     "footnote": "Roboto, sans-serif",
     "greek": "\"Gentium Book Plus\", serif",
@@ -29,6 +41,7 @@
   },
   "allAndika": {
     "body": "Andika, serif",
+    "body2": "\"Open Sans Condensed Light\", sans-serif",
     "heading": "Andika, serif",
     "footnote": "Andika, serif",
     "greek": "Andika, serif",
@@ -36,8 +49,9 @@
   },
   "charisOpen": {
     "body": "\"Charis SIL\", serif",
+    "body2": "\"Open Sans Condensed Light\", sans-serif",
     "heading": "\"Open Sans\", serif",
-    "footnotes": "\"Charis SIL\", serif",
+    "footnote": "\"Charis SIL\", serif",
     "greek": "\"Gentium Book Plus\", serif",
     "hebrew": "\"Ezra SIL\", serif"
   }

--- a/scripts/make_pdf.js
+++ b/scripts/make_pdf.js
@@ -5,7 +5,7 @@ const {
 const commander = require('commander');
 const fse = require('fs-extra');
 const path = require('path');
-const parseCommandLineArguments = require('../src/helpers/cli-parser');
+const { parseCommandLineArguments } = require('../src/helpers');
 
 const options = parseCommandLineArguments();
 

--- a/src/assemblePdfs.js
+++ b/src/assemblePdfs.js
@@ -3,12 +3,12 @@ const {
 } = require('pdf-lib');
 const {
     loadTemplate,
-    doPuppet
+    doPuppet,
+    constants
 } = require("./helpers");
 const fontKit = require('fontkit');
 const fse = require("fs-extra");
 const path = require("path");
-const {PAGE_SIZES} = require("./helpers/constants");
 
 /**
  * Generates HTML for page numbers and converts it to a PDF.
@@ -102,13 +102,13 @@ const makeFromDouble = async function (manifestStep, pageSize, fontBytes) {
         page1.drawPage(preamble, {
             xScale: 1,
             yScale: 1,
-            x: -(PAGE_SIZES.A3P.pageSize[1] - (pageSize[0] * 2)) / 2,
+            x: -(constants.PAGE_SIZES.A3P.pageSize[1] - (pageSize[0] * 2)) / 2,
             y: page1.getHeight() / 2 - pdfPageToCopy.getHeight() / 2,
         });
         page2.drawPage(preamble, {
             xScale: 1,
             yScale: 1,
-            x: -((PAGE_SIZES.A3P.pageSize[1] - (pageSize[0] * 2)) / 2 + pageSize[0]),
+            x: -((constants.PAGE_SIZES.A3P.pageSize[1] - (pageSize[0] * 2)) / 2 + pageSize[0]),
             y: page2.getHeight() / 2 - (pdfPageToCopy.getHeight() / 2),
         });
     }

--- a/src/helpers/cli-parser.js
+++ b/src/helpers/cli-parser.js
@@ -57,6 +57,12 @@ const parseCommandLineArguments = () => {
             VALIDATORS.steps,
             constants.STEPS_OPTIONS["ALL"]
         )
+        .option(
+            '-F, --fonts <fontsType>',
+            `The set of fonts to use. Options are ${Object.keys(constants.FONT_SETS).join(', ')}`,
+            VALIDATORS.fonts,
+            constants.FONT_SETS["allGentium"]
+        )
 
     program.parse(process.argv);
 

--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const os = require('os');
 const pageSizes = require('../../resources/pages.json');
+const fontSets = require('../../resources/fonts.json');
 
 const constants = {
     VERSION: "0.0.1",
@@ -13,7 +14,8 @@ const constants = {
         "ASSEMBLE": ["assemble"],
         "ALL": ["originate", "assemble"]
     },
-    PAGE_SIZES: pageSizes
+    PAGE_SIZES: pageSizes,
+    FONT_SETS: fontSets
 };
 
 module.exports = constants;

--- a/src/helpers/validators.js
+++ b/src/helpers/validators.js
@@ -57,6 +57,12 @@ const VALIDATORS = {
             throw new commander.InvalidArgumentError(`'${stepOptName}' is not one of ${Object.keys(constants.STEPS_OPTIONS)}`)
         }
         return constants.STEPS_OPTIONS[stepOptName];
+    },
+    fonts: fontName => {
+        if (!(Object.keys(constants.FONT_SETS).includes(fontName))) {
+            throw new commander.InvalidArgumentError(`'${fontName}' is not one of ${Object.keys(constants.FONT_SETS)}`)
+        }
+        return constants.STEPS_OPTIONS[fontName];
     }
 };
 

--- a/src/helpers/validators.js
+++ b/src/helpers/validators.js
@@ -42,7 +42,7 @@ const VALIDATORS = {
     pageFormat: newVal => {
         const ucFormat = newVal.toUpperCase();
         if (!(ucFormat in constants.PAGE_SIZES)) {
-            throw new commander.InvalidArgumentError(`'${ucFormat}' is not one of ${Object.keys(constants.PAGE_SIZES)}`)
+            throw new commander.InvalidArgumentError(`'${ucFormat}' is not one of ${Object.keys(constants.PAGE_SIZES).join(', ')}`)
         }
         return constants.PAGE_SIZES[ucFormat];
     },
@@ -54,15 +54,15 @@ const VALIDATORS = {
     },
     steps: stepOptName => {
         if (!(Object.keys(constants.STEPS_OPTIONS).includes(stepOptName))) {
-            throw new commander.InvalidArgumentError(`'${stepOptName}' is not one of ${Object.keys(constants.STEPS_OPTIONS)}`)
+            throw new commander.InvalidArgumentError(`'${stepOptName}' is not one of ${Object.keys(constants.STEPS_OPTIONS).join(', ')}`)
         }
         return constants.STEPS_OPTIONS[stepOptName];
     },
     fonts: fontName => {
         if (!(Object.keys(constants.FONT_SETS).includes(fontName))) {
-            throw new commander.InvalidArgumentError(`'${fontName}' is not one of ${Object.keys(constants.FONT_SETS)}`)
+            throw new commander.InvalidArgumentError(`'${fontName}' is not one of ${Object.keys(constants.FONT_SETS).join(', ')}`)
         }
-        return constants.STEPS_OPTIONS[fontName];
+        return constants.FONT_SETS[fontName];
     }
 };
 

--- a/src/helpers/validators.js
+++ b/src/helpers/validators.js
@@ -13,6 +13,7 @@ const commander = require('commander');
  * - pageFormat: Validates predefined page sizes.
  * - book: Checks for valid Paratext-style book code.
  * - steps: Validates processing steps options.
+ * - fonts: Validates predefined fonts for the output document.
  *
  * Usage: `VALIDATORS[key](value)` to validate each command-line option.
  */
@@ -54,13 +55,13 @@ const VALIDATORS = {
     },
     steps: stepOptName => {
         if (!(Object.keys(constants.STEPS_OPTIONS).includes(stepOptName))) {
-            throw new commander.InvalidArgumentError(`'${stepOptName}' is not one of ${Object.keys(constants.STEPS_OPTIONS).join(', ')}`)
+            throw new commander.InvalidArgumentError(`'${stepOptName}' is not one of ${Object.keys(constants.STEPS_OPTIONS).join(', ')}`);
         }
         return constants.STEPS_OPTIONS[stepOptName];
     },
     fonts: fontName => {
         if (!(Object.keys(constants.FONT_SETS).includes(fontName))) {
-            throw new commander.InvalidArgumentError(`'${fontName}' is not one of ${Object.keys(constants.FONT_SETS).join(', ')}`)
+            throw new commander.InvalidArgumentError(`'${fontName}' is not one of ${Object.keys(constants.FONT_SETS).join(', ')}`);
         }
         return constants.FONT_SETS[fontName];
     }

--- a/src/originatePdfs.js
+++ b/src/originatePdfs.js
@@ -1,5 +1,5 @@
 const path = require("path");
-const {loadTemplates, setupOneCSS, checkCssSubstitution, constants} = require("./helpers");
+const { loadTemplates, setupOneCSS, checkCssSubstitution } = require("./helpers");
 const fse = require("fs-extra");
 const {
     do2ColumnSection,

--- a/src/originatePdfs.js
+++ b/src/originatePdfs.js
@@ -1,5 +1,5 @@
 const path = require("path");
-const {loadTemplates, setupOneCSS, checkCssSubstitution} = require("./helpers");
+const {loadTemplates, setupOneCSS, checkCssSubstitution, constants} = require("./helpers");
 const fse = require("fs-extra");
 const {
     do2ColumnSection,
@@ -12,7 +12,6 @@ const {
     doParaBibleSection,
     doBiblePlusNotesSection
 } = require("./sectionHandlers");
-
 const setupCSS = options => {
     const cssFilenames = fse.readdirSync(path.join(__dirname, "..", "static", "resources"))
         .filter(name => name.endsWith(".css"));
@@ -37,7 +36,13 @@ const setupCSS = options => {
             ["COLUMNGAP", pageFormat.columnGap[spaceOption]],
             ["HALFCOLUMNGAP", pageFormat.columnGap[spaceOption] / 2],
             ["2COLUMNWIDTH", (pageBodyWidth - pageFormat.columnGap[spaceOption]) / 2],
-            ["3COLUMNWIDTH", (pageBodyWidth - (pageFormat.columnGap[spaceOption] * 2)) / 3]
+            ["3COLUMNWIDTH", (pageBodyWidth - (pageFormat.columnGap[spaceOption] * 2)) / 3],
+            ["BODYFONT", constants.FONT_SETS[options.fonts.body]],
+            ["HEADINGFONT", constants.FONT_SETS[options.fonts.heading]],
+            ["NOTEFONT", constants.FONT_SETS[options.fonts.note]],
+            ["FOOTNOTEFONT", constants.FONT_SETS[options.fonts.footnote]],
+            ["GREEKFONT", constants.FONT_SETS[options.fonts.greek]],
+            ["HEBREWFONT", constants.FONT_SETS[options.fonts.hebrew]],
         ]) {
             fileContent = setupOneCSS(fileContent, placeholder, "%%", value);
         }

--- a/src/originatePdfs.js
+++ b/src/originatePdfs.js
@@ -37,12 +37,12 @@ const setupCSS = options => {
             ["HALFCOLUMNGAP", pageFormat.columnGap[spaceOption] / 2],
             ["2COLUMNWIDTH", (pageBodyWidth - pageFormat.columnGap[spaceOption]) / 2],
             ["3COLUMNWIDTH", (pageBodyWidth - (pageFormat.columnGap[spaceOption] * 2)) / 3],
-            ["BODYFONT", constants.FONT_SETS[options.fonts.body]],
-            ["HEADINGFONT", constants.FONT_SETS[options.fonts.heading]],
-            ["NOTEFONT", constants.FONT_SETS[options.fonts.note]],
-            ["FOOTNOTEFONT", constants.FONT_SETS[options.fonts.footnote]],
-            ["GREEKFONT", constants.FONT_SETS[options.fonts.greek]],
-            ["HEBREWFONT", constants.FONT_SETS[options.fonts.hebrew]],
+            ["BODYFONT", options.fonts.body],
+            ["BODYFONT2", options.fonts.body2 || options.fonts.body],
+            ["HEADINGFONT", options.fonts.heading],
+            ["FOOTNOTEFONT", options.fonts.footnote],
+            ["GREEKFONT", options.fonts.greek],
+            ["HEBREWFONT", options.fonts.hebrew],
         ]) {
             fileContent = setupOneCSS(fileContent, placeholder, "%%", value);
         }

--- a/static/resources/2_col_header_page_styles.css
+++ b/static/resources/2_col_header_page_styles.css
@@ -15,7 +15,7 @@
 body {
     font-size: 9pt;
     line-height: 10pt;
-    font-family: "Gentium Book Plus", serif;
+    font-family: %%BODYFONT%%;
 }
 
 p {

--- a/static/resources/2_col_page_styles.css
+++ b/static/resources/2_col_page_styles.css
@@ -22,7 +22,7 @@
 body {
     font-size: 9pt;
     line-height: 10pt;
-    font-family: "Gentium Book Plus", serif;
+    font-family: %%BODYFONT%%;
 }
 
 p {
@@ -39,6 +39,7 @@ h1 {
     border-bottom: 2pt solid black;
     padding-bottom: 2pt;
     width: %%PAGEBODYWIDTH%%pt;
+    font-family: %%HEADINGFONT%%;
 }
 
 h2.verseRecordHeadLeft, h2.verseRecordHeadRight {
@@ -48,14 +49,17 @@ h2.verseRecordHeadLeft, h2.verseRecordHeadRight {
     font-weight: bold;
     margin: 0;
     width: %%2COLUMNWIDTH%%pt;
+    font-family: %%HEADINGFONT%%;
 }
 
 h2.verseRecordHeadLeft {
     text-align: left;
+    font-family: %%HEADINGFONT%%;
 }
 
 h2.verseRecordHeadRight {
     text-align: right;
+    font-family: %%HEADINGFONT%%;
 }
 
 .leftColumn {
@@ -106,18 +110,22 @@ h2.verseRecordHeadRight {
 .head1 {
     display: inline-block;
     width: 200pt;
+    font-family: %%HEADINGFONT%%;
 }
 .head2 {
     display: inline-block;
     width: 332pt;
+    font-family: %%HEADINGFONT%%;
 }
 .head3 {
     display: inline-block;
     width: 200pt;
+    font-family: %%HEADINGFONT%%;
 }
 .head4 {
     display: inline-block;
     width: 188pt;
+    font-family: %%HEADINGFONT%%;
 }
 .cv {
     font-style: italic;
@@ -131,21 +139,9 @@ h2.verseRecordHeadRight {
     margin-bottom: 0pt;
     padding-left: 6pt;
     text-indent: -6pt;
+    font-family: %%FOOTNOTEFONT%%;
 }
 
 .note .b {
-    font-weight: bold;
-}
-
-::footnote-call {
-    font-weight: bold;
-    font-size: 70%;
-    vertical-align: baseline;
-    position: relative;
-    top: -0.5em;
-    padding-left: 1pt;
-}
-
-::footnote-marker {
     font-weight: bold;
 }

--- a/static/resources/4_col_header_page_styles.css
+++ b/static/resources/4_col_header_page_styles.css
@@ -19,7 +19,7 @@
 body {
     font-size: 9pt;
     line-height: 10pt;
-    font-family: "Gentium Book Plus", serif;
+    font-family: %%BODYFONT%%;
 }
 
 p {
@@ -36,6 +36,7 @@ h1 {
     border-bottom: 2pt solid black;
     padding-bottom: 2pt;
     width: %%PAGEBODYWIDTH%%pt;
+    font-family: %%HEADINGFONT%%;
 }
 
 h2.verseRecordHeadLeft, h2.verseRecordHeadRight {
@@ -45,6 +46,7 @@ h2.verseRecordHeadLeft, h2.verseRecordHeadRight {
     font-weight: bold;
     margin: 0;
     width: %%PAGEBODYWIDTH%%pt;
+    font-family: %%HEADINGFONT%%;
 }
 
 .versoPage {
@@ -95,18 +97,22 @@ h2.verseRecordHeadLeft, h2.verseRecordHeadRight {
 .head1 {
     display: inline-block;
     width: 200pt;
+    font-family: %%HEADINGFONT%%;
 }
 .head2 {
     display: inline-block;
     width: 332pt;
+    font-family: %%HEADINGFONT%%;
 }
 .head3 {
     display: inline-block;
     width: 200pt;
+    font-family: %%HEADINGFONT%%;
 }
 .head4 {
     display: inline-block;
     width: 188pt;
+    font-family: %%HEADINGFONT%%;
 }
 .cv {
     font-style: italic;
@@ -117,4 +123,5 @@ h2.verseRecordHeadLeft, h2.verseRecordHeadRight {
     break-after: page;
     vertical-align: top;
     display: inline-flex;
+    font-family: %%HEADINGFONT%%;
 }

--- a/static/resources/4_col_page_styles.css
+++ b/static/resources/4_col_page_styles.css
@@ -22,7 +22,7 @@
 body {
     font-size: 9pt;
     line-height: 10pt;
-    font-family: "Gentium Book Plus", serif;
+    font-family: %%BODYFONT%%;
 }
 
 p {
@@ -39,6 +39,7 @@ h1 {
     border-bottom: 2pt solid black;
     padding-bottom: 2pt;
     width: %%PAGEBODYWIDTH%%pt;
+    font-family: %%HEADINGFONT%%;
 }
 
 h2.verseRecordHeadLeft, h2.verseRecordHeadRight {
@@ -49,6 +50,7 @@ h2.verseRecordHeadLeft, h2.verseRecordHeadRight {
     margin: 0;
     width: %%PAGEBODYWIDTH%%pt;
     text-align: center;
+    font-family: %%HEADINGFONT%%;
 }
 
 .versoPage {
@@ -93,6 +95,7 @@ h2.verseRecordHeadLeft, h2.verseRecordHeadRight {
     margin-bottom: 0pt;
     padding-left: 6pt;
     text-indent: -6pt;
+    font-family: %%FOOTNOTEFONT%%;
 }
 
 .note .b {
@@ -115,18 +118,22 @@ h2.verseRecordHeadLeft, h2.verseRecordHeadRight {
 .head1 {
     display: inline-block;
     width: 200pt;
+    font-family: %%HEADINGFONT%%;
 }
 .head2 {
     display: inline-block;
     width: 332pt;
+    font-family: %%HEADINGFONT%%;
 }
 .head3 {
     display: inline-block;
     width: 200pt;
+    font-family: %%HEADINGFONT%%;
 }
 .head4 {
     display: inline-block;
     width: 188pt;
+    font-family: %%HEADINGFONT%%;
 }
 .cv {
     font-style: italic;
@@ -139,4 +146,5 @@ h2.verseRecordHeadLeft, h2.verseRecordHeadRight {
     font-weight: bold;
     margin: 0;
     width: %%PAGEBODYWIDTH%%pt;
+    font-family: %%HEADINGFONT%%;
 }

--- a/static/resources/bcv_bible_page_styles.css
+++ b/static/resources/bcv_bible_page_styles.css
@@ -22,7 +22,7 @@
 body {
     font-size: 9pt;
     line-height: 10pt;
-    font-family: "Gentium Book Plus", serif;
+    font-family: %%BODYFONT%%;
 }
 
 p {
@@ -39,6 +39,7 @@ h1 {
     border-bottom: 2pt solid black;
     padding-bottom: 2pt;
     width: %%PAGEBODYWIDTH%%pt;
+    font-family: %%HEADINGFONT%%;
 }
 .cvCol {
     font-style: italic;
@@ -76,6 +77,7 @@ h1 {
     text-align: justify;
     float: footnote;
     margin-bottom: 0pt;
+    font-family: %%FOOTNOTEFONT%%;
 }
 
 .note .b {

--- a/static/resources/bible_plus_notes_page_styles.css
+++ b/static/resources/bible_plus_notes_page_styles.css
@@ -22,7 +22,7 @@
 body {
     font-size: 9pt;
     line-height: 10pt;
-    font-family: "Gentium Book Plus", serif;
+    font-family: %%BODYFONT%%;
 }
 
 p {
@@ -31,6 +31,7 @@ p {
 }
 
 h1 {
+    font-family: %%HEADINGFONT%%;
     font-size: 14pt;
     line-height: 20pt;
     font-weight: bold;
@@ -77,6 +78,7 @@ h1 {
     font-weight: bold;
 }
 .note {
+    font-family: %%FOOTNOTEFONT%%;
     display: list-item;
     font-size: 7pt;
     line-height: 9pt;

--- a/static/resources/bible_plus_notes_page_styles.css
+++ b/static/resources/bible_plus_notes_page_styles.css
@@ -78,7 +78,7 @@ h1 {
     font-weight: bold;
 }
 .note {
-    font-family: %%FOOTNOTEFONT%%;
+    font-family: %%BODYFONT2%%;
     display: list-item;
     font-size: 7pt;
     line-height: 9pt;

--- a/static/resources/juxta_page_styles.css
+++ b/static/resources/juxta_page_styles.css
@@ -19,7 +19,7 @@
 body {
     font-size: 9pt;
     line-height: 10pt;
-    font-family: "Gentium Book Plus", serif;
+    font-family: %%BODYFONT%%;
 }
 
 p {
@@ -36,6 +36,7 @@ h1 {
     border-bottom: 2pt solid black;
     padding-bottom: 2pt;
     width: %%PAGEBODYWIDTH%%pt;
+    font-family: %%HEADINGFONT%%;
 }
 
 h2.phraseN {
@@ -48,6 +49,7 @@ h2.phraseN {
     border-bottom: solid 1.5pt black;
     width: %%PAGEBODYWIDTH%%pt;
     text-align: left;
+    font-family: %%HEADINGFONT%%;
 }
 
 h2.sentenceRef {
@@ -60,10 +62,11 @@ h2.sentenceRef {
     border-bottom: solid 1.5pt black;
     width: %%PAGEBODYWIDTH%%pt;
     text-align: right;
+    font-family: %%HEADINGFONT%%;
 }
 
 .transAbbr {
-    font-family: "Gentium Book Plus", serif;
+    font-family: %%BODYFONT%%;
     font-weight: bold;
     font-style: italic;
     padding-right: 4pt;
@@ -124,7 +127,7 @@ h2.sentenceRef {
     margin: 0;
     padding: 0;
     padding-right: %%HALFCOLUMNGAP%%pt;
-
+    font-family: %%GREEKFONT%%;
 }
 
 .jxlGloss {

--- a/static/resources/non_juxta_page_styles.css
+++ b/static/resources/non_juxta_page_styles.css
@@ -22,7 +22,7 @@
 body {
     font-size: 9pt;
     line-height: 10pt;
-    font-family: "Gentium Book Plus", serif;
+    font-family: %%BODYFONT%%;
 }
 
 p {
@@ -38,6 +38,7 @@ h1 {
     border-bottom: 2pt solid black;
     padding-bottom: 2pt;
     text-align: left;
+    font-family: %%HEADINGFONT%%;
 }
 
 .front {}
@@ -59,12 +60,14 @@ h1 {
     font-weight: bold;
     font-style: italic;
     text-align: left;
+    font-family: %%HEADINGFONT%%;
 }
 .half_page {
     break-before: page;
 }
 .half_page h2 {
     font-weight: bold;
+    font-family: %%HEADINGFONT%%;
 }
 .title_page {
     text-align: center;
@@ -76,28 +79,33 @@ h1 {
     font-size: 18pt;
     border: none;
     margin-bottom: 60pt;
+    font-family: %%HEADINGFONT%%;
 }
 
 .title_page > h3 {
     text-align: center;
     font-size: 14pt;
     border: none;
+    font-family: %%HEADINGFONT%%;
 }
 
 h3.pub_details {
     margin-top: 144pt;
     font-weight: normal;
     font-size: 12pt;
+    font-family: %%HEADINGFONT%%;
 }
 
 h3.pub_details2 {
     margin-top: 288pt;
     font-weight: normal;
     font-size: 12pt;
+    font-family: %%HEADINGFONT%%;
 }
 
 h3.descriptif {
     margin-bottom: 60pt;
+    font-family: %%HEADINGFONT%%;
 }
 
 p.resource {
@@ -130,6 +138,7 @@ p.small-gap {
     font-weight: bold;
     font-style: italic;
     text-align: left;
+    font-family: %%HEADINGFONT%%;
 }
 .mode_emploi {}
 
@@ -183,6 +192,7 @@ p.small-gap {
     padding-left: 1.2em;
     text-indent: -1.2em;
     text-align: left;
+    font-family: %%FOOTNOTEFONT%%;
 }
 
 .note .b {
@@ -241,15 +251,6 @@ p.small-gap {
     text-align: center;
     margin-bottom: 20pt;
     margin-top: 10pt;
-}
-.note {
-    font-size: 7pt;
-    line-height: 9pt;
-    text-align: justify;
-    float: footnote;
-    margin-bottom: 0pt;
-    padding-left: 6pt;
-    text-indent: -6pt;
 }
 ::footnote-call {
     font-weight: bold;

--- a/static/resources/page_number_master_styles.css
+++ b/static/resources/page_number_master_styles.css
@@ -13,7 +13,7 @@
 }
 body {
     font-size: 9pt;
-    font-family: "Gentium Book Plus", serif;
+    font-family: %%BODYFONT%%;
     text-align: center;
 }
 

--- a/static/resources/para_bible_page_styles.css
+++ b/static/resources/para_bible_page_styles.css
@@ -24,7 +24,7 @@
 body {
     font-size: 9pt;
     line-height: 10pt;
-    font-family: "Gentium Book Plus", serif;
+    font-family: %%BODYFONT%%;
     text-align: justify;
     text-align-last: left;
 }
@@ -47,6 +47,7 @@ h1 {
     border-bottom: 2pt solid black;
     padding-bottom: 2pt;
     width: 388pt;
+    font-family: %%HEADINGFONT%%;
 }
 
 ::footnote-call {
@@ -75,6 +76,7 @@ h1 {
     font-size: 7pt;
     line-height: 10pt;
     float: footnote;
+    font-family: %%FOOTNOTEFONT%%;
 }
 .paras_usfm_hanging_graft {
 }
@@ -84,6 +86,7 @@ h1 {
     font-size: 20pt;
     line-height: 30pt;
     text-align: center;
+    font-family: %%HEADINGFONT%%;
 }
 .paras_usfm_imt2 {
     font-weight: bold;
@@ -91,6 +94,7 @@ h1 {
     font-size: 14pt;
     line-height: 20pt;
     text-align: center;
+    font-family: %%HEADINGFONT%%;
 }
 .paras_usfm_imt3 {
     font-weight: bold;
@@ -98,6 +102,7 @@ h1 {
     font-size: 12pt;
     line-height: 20pt;
     text-align: center;
+    font-family: %%HEADINGFONT%%;
 }
 .paras_usfm_ip {
     text-indent: 12pt;
@@ -118,16 +123,19 @@ h1 {
     font-style: italic;
     font-size: 20pt;
     line-height: 30pt;
+    font-family: %%HEADINGFONT%%;
 }
 .paras_usfm_is2 {
     font-style: italic;
     font-size: 14pt;
     line-height: 20pt;
+    font-family: %%HEADINGFONT%%;
 }
 .paras_usfm_is3 {
     font-style: italic;
     font-size: 12pt;
     line-height: 20pt;
+    font-family: %%HEADINGFONT%%;
 }
 .paras_usfm_li {
     list-style-type: disc;
@@ -153,14 +161,17 @@ h1 {
     font-size: 12pt;
     line-height: 20pt;
     font-style: italic;
+    font-family: %%HEADINGFONT%%;
 }
 .paras_usfm_ms {
     font-size: 12pt;
     line-height: 20pt;
     font-weight: bold;
+    font-family: %%HEADINGFONT%%;
 }
 .paras_usfm_ms2 {
     font-weight: bold;
+    font-family: %%HEADINGFONT%%;
 }
 .paras_usfm_mt {
     font-weight: bold;
@@ -168,6 +179,7 @@ h1 {
     font-size: 20pt;
     line-height: 30pt;
     text-align: center;
+    font-family: %%HEADINGFONT%%;
 }
 .paras_usfm_mt2 {
     font-weight: bold;
@@ -175,6 +187,7 @@ h1 {
     font-size: 14pt;
     line-height: 20pt;
     text-align: center;
+    font-family: %%HEADINGFONT%%;
 }
 .paras_usfm_mt3 {
     font-weight: bold;
@@ -182,6 +195,7 @@ h1 {
     font-size: 12pt;
     line-height: 20pt;
     text-align: center;
+    font-family: %%HEADINGFONT%%;
 }
 .paras_usfm_nb {
 }
@@ -230,25 +244,30 @@ h1 {
 }
 .paras_usfm_r {
     font-weight: bold;
+    font-family: %%HEADINGFONT%%;
 }
 .paras_usfm_s {
     font-style: italic;
     font-size: 20pt;
     line-height: 30pt;
+    font-family: %%HEADINGFONT%%;
 }
 .paras_usfm_s2 {
     font-style: italic;
     font-size: 14pt;
     line-height: 20pt;
+    font-family: %%HEADINGFONT%%;
 }
 .paras_usfm_s3 {
     font-style: italic;
     font-size: 12pt;
     line-height: 20pt;
+    font-family: %%HEADINGFONT%%;
 }
 .paras_usfm_sr {
     font-size: 12pt;
     line-height: 20pt;
+    font-family: %%HEADINGFONT%%;
 }
 .paras_usfm_tr {
 }

--- a/static/resources/simple_juxta_page_styles.css
+++ b/static/resources/simple_juxta_page_styles.css
@@ -22,7 +22,7 @@
 body {
     font-size: 9pt;
     line-height: 10pt;
-    font-family: "Gentium Book Plus", serif;
+    font-family: %%BODYFONT%%;
 }
 
 p {
@@ -39,6 +39,7 @@ h1 {
     border-bottom: 2pt solid black;
     padding-bottom: 2pt;
     width: %%PAGEBODYWIDTH%%pt;
+    font-family: %%HEADINGFONT%%;
 }
 
 h2.sentenceHeader {
@@ -49,6 +50,7 @@ h2.sentenceHeader {
     margin: 0;
     width: %%PAGEBODYWIDTH%%pt;
     text-align: center;
+    font-family: %%HEADINGFONT%%;
 }
 
 .phraseN {
@@ -87,6 +89,7 @@ h2.sentenceHeader {
     margin: 0;
     padding: 0;
     padding-right: %%HALFCOLUMNGAP%%pt;
+    font-family: %%GREEKFONT%%;
 }
 
 .jxlGloss {
@@ -136,6 +139,7 @@ h2.sentenceHeader {
     -webkit-column-break-inside: avoid;
     padding-left: 6pt;
     text-indent: -6pt;
+    font-family: %%FOOTNOTEFONT%%;
 }
 
 .note .b {


### PR DESCRIPTION
This PR introduces a list of sets of fonts for use in the PDF. The all-gentium default may be overwritten using the `-F` option. To test

`node scripts/make_pdf.js -c config/fr/kitchen_sink.json -o ~/Downloads/ks.pdf -v -f -p executive -b TIT`

for the default, then

`node scripts/make_pdf.js -c config/fr/kitchen_sink.json -o ~/Downloads/ks.pdf -v -f -p executive -b TIT -F allAndika`

assuming you have installed

https://fonts.google.com/specimen/Andika