### PR TITLE
Markdown monospace font option; fix some validation and default values

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jxl-pdf",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Printable Scripture-related PDFs",
   "main": "src/index.js",
   "dependencies": {

--- a/resources/fonts.json
+++ b/resources/fonts.json
@@ -9,6 +9,7 @@
     "heading": "\"Gentium Book Plus\", serif",
     "footnote": "\"Gentium Book Plus\", serif",
     "greek": "\"Gentium Book Plus\", serif",
+    "mono": "\"Courier New\", \"Liberation Sans Mono\", \"Deja Vu Sans Mono\", monospace",
     "hebrew": "\"Ezra SIL\", serif"
   },
   "gentiumOpen": {
@@ -20,6 +21,7 @@
     "body2": "\"Open Sans Condensed Light\", sans-serif",
     "heading": "\"Gentium Book Plus\", serif",
     "footnote": "\"Gentium Book Plus\", serif",
+    "mono": "\"Courier New\", \"Liberation Sans Mono\", \"Deja Vu Sans Mono\", monospace",
     "greek": "\"Gentium Book Plus\", serif",
     "hebrew": "\"Ezra SIL\", serif"
   },
@@ -32,6 +34,7 @@
     "body2": "\"Charis SIL\", serif",
     "heading": "\"Charis SIL\", serif",
     "footnote": "\"Charis SIL\", serif",
+    "mono": "\"Courier New\", \"Liberation Sans Mono\", \"Deja Vu Sans Mono\", monospace",
     "greek": "\"Gentium Book Plus\", serif",
     "hebrew": "\"Ezra SIL\", serif"
   },
@@ -44,6 +47,7 @@
     "body2": "\"Open Sans Condensed Light\", sans-serif",
     "heading": "\"Charis SIL\", serif",
     "footnote": "\"Charis SIL\", serif",
+    "mono": "\"Courier New\", \"Liberation Sans Mono\", \"Deja Vu Sans Mono\", monospace",
     "greek": "\"Gentium Book Plus\", serif",
     "hebrew": "\"Ezra SIL\", serif"
   },
@@ -56,6 +60,7 @@
     "body2": "\"Open Sans Condensed Light\", sans-serif",
     "heading": "\"Open Sans\", serif",
     "footnote": "\"Open Sans Condensed Light\", serif",
+    "mono": "\"Courier New\", \"Liberation Sans Mono\", \"Deja Vu Sans Mono\", monospace",
     "greek": "\"Gentium Book Plus\", serif",
     "hebrew": "\"Ezra SIL\", serif"
   },
@@ -68,6 +73,7 @@
     "body2": "Cardo, serif",
     "heading": "Cardo, serif",
     "footnote": "Cardo, serif",
+    "mono": "\"Courier New\", \"Liberation Sans Mono\", \"Deja Vu Sans Mono\", monospace",
     "greek": "Cardo, serif",
     "hebrew": "\"Ezra SIL\", serif"
   },
@@ -80,6 +86,7 @@
     "body2": "\"Open Sans Condensed Light\", sans-serif",
     "heading": "Cardo, serif",
     "footnote": "Cardo, serif",
+    "mono": "\"Courier New\", \"Liberation Sans Mono\", \"Deja Vu Sans Mono\", monospace",
     "greek": "Cardo, serif",
     "hebrew": "\"Ezra SIL\", serif"
   },
@@ -92,6 +99,7 @@
     "body2": "Roboto, sans-serif",
     "heading": "Roboto, sans-serif",
     "footnote": "Roboto, sans-serif",
+    "mono": "\"Courier New\", \"Liberation Sans Mono\", \"Deja Vu Sans Mono\", monospace",
     "greek": "\"Gentium Book Plus\", serif",
     "hebrew": "\"Ezra SIL\", serif"
   },
@@ -104,6 +112,7 @@
     "body2": "\"Charis SIL\", serif",
     "heading": "Andika, serif",
     "footnote": "Andika, serif",
+    "mono": "\"Courier New\", \"Liberation Sans Mono\", \"Deja Vu Sans Mono\", monospace",
     "greek": "\"Charis SIL\", serif",
     "hebrew": "\"Ezra SIL\", serif"
   },
@@ -116,6 +125,7 @@
     "body2": "\"Noto Naskh Arabic\", sans-serif",
     "heading": "\"Noto Naskh Arabic\", serif",
     "footnote": "\"Noto Naskh Arabic\", serif",
+    "mono": "\"Courier New\", \"Liberation Sans Mono\", \"Deja Vu Sans Mono\", monospace",
     "greek": "\"Gentium Book Plus\", serif",
     "hebrew": "\"Ezra SIL\", serif"
   }

--- a/src/helpers/loadTemplates.js
+++ b/src/helpers/loadTemplates.js
@@ -8,6 +8,7 @@ const TEMPLATE_NAMES = [
     'simple_juxta_page',
     'non_juxta_page',
     'markdown_page',
+    'markdown_mono_page',
     'obs_page',
     'obs_plus_notes_page',
     '4_column_spread_page',

--- a/src/originatePdfs.js
+++ b/src/originatePdfs.js
@@ -45,6 +45,7 @@ const setupCSS = options => {
             ["BODYFONT2", options.fonts.body2 || options.fonts.body],
             ["HEADINGFONT", options.fonts.heading],
             ["FOOTNOTEFONT", options.fonts.footnote],
+            ["MONOFONT", options.fonts.mono],
             ["GREEKFONT", options.fonts.greek],
             ["HEBREWFONT", options.fonts.hebrew],
             ["BODYFONTSIZE", options.fontSizes.body.font],

--- a/src/sectionHandlerClasses/markdownSection.js
+++ b/src/sectionHandlerClasses/markdownSection.js
@@ -56,7 +56,18 @@ class MarkdownSection extends Section {
                         fr: "Afficher numéro de page"
                     },
                     typeName: "boolean",
-                    nValues: [1, 1]
+                    nValues: [1, 1],
+                    suggestedDefault: true
+                },
+                {
+                    id: "forceMono",
+                    label: {
+                        en: "Use monospace font",
+                        fr: "Utiliser police monospace"
+                    },
+                    typeName: "boolean",
+                    nValues: [0, 1],
+                    suggestedDefault: false
                 },
                 {
                     id: "md",
@@ -65,8 +76,7 @@ class MarkdownSection extends Section {
                         fr: "Source pour markdown"
                     },
                     typeName: "md",
-                    nValues: [1, 1],
-                    suggestedDefault: true
+                    nValues: [1, 1]
                 },
             ]
         }
@@ -76,7 +86,7 @@ class MarkdownSection extends Section {
         fse.writeFileSync(
             path.join(
                 options.htmlPath, `${section.id.replace('%%bookCode%%', bookCode)}.html`),
-            templates['markdown_page']
+            templates[section.content.forceMono ? 'markdown_mono_page': 'markdown_page']
                 .replace(
                     "%%TITLE%%",
                     `${section.id.replace('%%bookCode%%', bookCode)} - ${section.type}`

--- a/src/templates/markdown_mono_page.html
+++ b/src/templates/markdown_mono_page.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <link rel="stylesheet" href="../resources/markdown_mono_page_styles.css">
+    <link rel="icon" href="data:;base64,iVBORw0KGgo=">
+    <script src="../resources/paged.polyfill.js"></script>
+    <title>%%TITLE%%</title>
+</head>
+<body>
+%%BODY%%
+</body>
+</html>

--- a/static/resources/markdown_mono_page_styles.css
+++ b/static/resources/markdown_mono_page_styles.css
@@ -1,0 +1,62 @@
+%%%ATPAGE%%%
+
+body {
+    font-family: %%MONOFONT%%;
+    font-size: %%BODYFONTSIZE%%pt;
+    line-height: %%BODYLINEHEIGHT%%pt;
+}
+
+h1 {
+    font-size: %%H1FONTSIZE%%pt;
+    line-height: %%H1LINEHEIGHT%%pt;
+    font-weight: bold;
+    margin: 0;
+    margin-bottom: %%H1BOTTOMMARGIN%%pt;
+    border-bottom: %%H1BOTTOMBORDERWIDTH%%pt solid black;
+    padding-bottom: %%H1BOTTOMMARGIN%%pt;
+    width: %%PAGEBODYWIDTH%%pt;
+    font-family: %%MONOFONT%%;
+    break-after: avoid;
+}
+
+h2 {
+    margin: 0;
+    margin-top: %%BODYLINEHEIGHT%%pt;
+    padding: 0;
+    font-family: %%MONOFONT%%;
+    font-size:%%H2FONTSIZE%%pt;
+    line-height:%%H2LINEHEIGHT%%pt;
+}
+h3 {
+    margin: 0;
+    margin-top: %%BODYLINEHEIGHT%%pt;
+    padding: 0;
+    font-family: %%MONOFONT%%;
+    font-size:%%H3FONTSIZE%%pt;
+    line-height:%%H3LINEHEIGHT%%pt;
+    font-weight: normal;
+}
+h4 {
+    margin: 0;
+    margin-top: %%BODYLINEHEIGHT%%pt;
+    padding: 0;
+    font-family: %%MONOFONT%%;
+    font-size:%%H4FONTSIZE%%pt;
+    line-height:%%H4LINEHEIGHT%%pt;
+    font-weight: normal;
+    font-style: italic;
+}
+
+p {
+    margin: 0;
+    margin-bottom: %%BODYLINEHEIGHT%%pt;
+    padding: 0;
+}
+
+a {
+    text-decoration: none;
+    color: black;
+    font-style: italic;
+}
+
+%%%FOOTNOTE%%%


### PR DESCRIPTION
This PR addes an optional `forceMono` flag to the signature of Markdown sections. The use case is the 'half page' (first verso page with publication details) of many books. To do this I
- added a `mono` font to all the font set options
- added substitution of that value for CSS
- made alternative CSS and HTML template for monospace variant

Tested with value absent, set to false and set to true.